### PR TITLE
[ fix ] - Only one plugin was loaded

### DIFF
--- a/site/parser/addon-parser.php
+++ b/site/parser/addon-parser.php
@@ -534,9 +534,9 @@ class AddonParser {
         if(JFolder::exists($addons_path)) {
           $addons = JFolder::folders($addons_path);
           foreach ($addons as $addon) {
-            $path = $addons_path . '/' . $addon;
-            if(JFile::exists($path . '/site.php')) {
-              $elements[$addon] = $path;
+            $pa_path = $addons_path . '/' . $addon;
+            if(JFile::exists($pa_path . '/site.php')) {
+              $elements[$addon] = $pa_path;
             }
           }
         }


### PR DESCRIPTION
Using the $path variable inside the nested loop was overriding the outer one, so next loops were using the updated $path variable leading to not finding/loading the plugin